### PR TITLE
Add statement desciptor + description to membership

### DIFF
--- a/api/src/lib/errors.ts
+++ b/api/src/lib/errors.ts
@@ -2,7 +2,7 @@ import { Field, ObjectType, registerEnumType } from "type-graphql";
 
 import { ApolloError } from "apollo-server";
 
-enum ErrorCodes {
+export enum ErrorCodes {
   INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR",
   RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND",
   UNAUTHENTICATED = "UNATHENTICATED",

--- a/apps/web/src/components/CheckoutForm.tsx
+++ b/apps/web/src/components/CheckoutForm.tsx
@@ -133,11 +133,16 @@ const CheckoutFormBase: React.FC<CheckoutProps> = (
     let secret: string = clientSecret;
 
     if (!secret) {
-      const result: ExecutionResult<
-        GetMembershipMutation
-      > = await getMembership({
-        variables: { membership: props.tag }
-      });
+      let result: ExecutionResult<GetMembershipMutation>;
+      try {
+        result = await getMembership({
+          variables: { membership: props.tag }
+        });
+      } catch (e) {
+        handleError(e.message);
+        return;
+      }
+
       const data = result.data;
 
       if (!data) {


### PR DESCRIPTION
# Pull Request Description
Closes #94 

Add statement descriptor for ACM Membership payments that shows up on credit card statement as 'ACM* MEMBERSHIP'. 

Add a description to PaymentIntent to display on stripe dashboard

Waiting for the next release to merge.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
