### PR TITLE
Fix auth0 domain to be mstacm-test.auth0.com as default

### DIFF
--- a/api/.docker/web.env.default
+++ b/api/.docker/web.env.default
@@ -1,4 +1,4 @@
-AUTH0_DOMAIN=mstacm.auth0.com
+AUTH0_DOMAIN=mstacm-test.auth0.com
 
 AZURE_STORAGE_ACCOUNT=mstacm
 AZURE_STORAGE_ACCOUNT_KEY=changeme


### PR DESCRIPTION
# Pull Request Description

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
