### PR TITLE
Disable workspaces for 'api' preventing docker failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   "dependencies": {},
   "workspaces": {
     "packages": [
-      "api/",
-      "apps/*"
+      "apps/admin-web",
+      "apps/profile-web",
+      "apps/web",
+      "apps/resume-portal"
     ],
     "nohoist": [
       "**/babel**",

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,472 @@
     promise-polyfill "^8.1.3"
     unfetch "^4.1.0"
 
+"@aws-sdk/abort-controller@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-0.1.0-preview.5.tgz#2e1a1db3c0992dcca3b11198cdaf4206498ab0c4"
+  integrity sha512-+TqAh6bzof5l+5tOND9YTEJEVeMli518ignGbLlB8CuMMeNPtvjXg6lzf5+XQpNXZ8CCmjqxZ2X5i1mImdJtmw==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/apply-body-checksum-middleware@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/apply-body-checksum-middleware/-/apply-body-checksum-middleware-0.1.0-preview.5.tgz#4b6ecd5715408d847b6e05497c84da3ee2114b3f"
+  integrity sha512-jSaptiE/JgE6437X5okUyMOw/5gtNCnQsRpIK3eYxbOi4x1F+GbFgpB30mwDh/wClS1bSHl4DoE/pe8Te4d5MQ==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/bucket-endpoint-middleware@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/bucket-endpoint-middleware/-/bucket-endpoint-middleware-0.1.0-preview.5.tgz#b1b43fb191a92f14d47b6bbb79989128c8d7e51d"
+  integrity sha512-z6BvmYdXppREN9DweWjvZa7ZthhIVp9ElU3BBSwRcjYLrT/t2t7acYeYUlxR6qj+k01cbDdqPw0qG2iS2bDRKA==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/client-s3-node@^0.1.0-preview.2":
+  version "0.1.0-preview.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3-node/-/client-s3-node-0.1.0-preview.2.tgz#9e56e94e9cf0e49ee9616d66f5a489255ee95226"
+  integrity sha512-sQj8KnijskzIijl/ETJpoygcN4o0AKBtZtXp6eiJjhLZf1RAX33Bd1QzSgScfElY/XVAMgntzWWvBm8VhUu+cQ==
+  dependencies:
+    "@aws-sdk/apply-body-checksum-middleware" "^0.1.0-preview.4"
+    "@aws-sdk/bucket-endpoint-middleware" "^0.1.0-preview.4"
+    "@aws-sdk/config-resolver" "^0.1.0-preview.4"
+    "@aws-sdk/core-handler" "^0.1.0-preview.4"
+    "@aws-sdk/credential-provider-node" "^0.1.0-preview.5"
+    "@aws-sdk/hash-node" "^0.1.0-preview.4"
+    "@aws-sdk/hash-stream-node" "^0.1.0-preview.5"
+    "@aws-sdk/location-constraint-middleware" "^0.1.0-preview.4"
+    "@aws-sdk/middleware-content-length" "^0.1.0-preview.4"
+    "@aws-sdk/middleware-expect-continue" "^0.1.0-preview.4"
+    "@aws-sdk/middleware-header-default" "^0.1.0-preview.4"
+    "@aws-sdk/middleware-serializer" "^0.1.0-preview.4"
+    "@aws-sdk/middleware-stack" "^0.1.0-preview.5"
+    "@aws-sdk/node-http-handler" "^0.1.0-preview.5"
+    "@aws-sdk/protocol-rest" "^0.1.0-preview.6"
+    "@aws-sdk/query-error-unmarshaller" "^0.1.0-preview.5"
+    "@aws-sdk/region-provider" "^0.1.0-preview.4"
+    "@aws-sdk/retry-middleware" "^0.1.0-preview.4"
+    "@aws-sdk/s3-error-unmarshaller" "^0.1.0-preview.2"
+    "@aws-sdk/signature-v4" "^0.1.0-preview.5"
+    "@aws-sdk/signing-middleware" "^0.1.0-preview.5"
+    "@aws-sdk/ssec-middleware" "^0.1.0-preview.4"
+    "@aws-sdk/stream-collector-node" "^0.1.0-preview.4"
+    "@aws-sdk/types" "^0.1.0-preview.4"
+    "@aws-sdk/url-parser-node" "^0.1.0-preview.4"
+    "@aws-sdk/util-base64-node" "^0.1.0-preview.2"
+    "@aws-sdk/util-body-length-node" "^0.1.0-preview.3"
+    "@aws-sdk/util-user-agent-node" "^0.1.0-preview.5"
+    "@aws-sdk/util-utf8-node" "^0.1.0-preview.2"
+    "@aws-sdk/xml-body-builder" "^0.1.0-preview.4"
+    "@aws-sdk/xml-body-parser" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/config-resolver@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.5.tgz#9d3655f0ac694bcc23d7af6498909c87723c7322"
+  integrity sha512-hwhX4WfKpaW2zeISBo6TYlreN77yuWwYNQ8kVP+8PkWgVHzRp733c6VbxrcVAF35bVAhxQhFqoA9ZKv67OMiiw==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/core-handler@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.5.tgz#302fb3ee80dc89fddadbbb1ec5d4942112b7aba5"
+  integrity sha512-LnfJ9naOAMFh/0J7nZ1puT1H2AHHcFTdITJGAmoaejnmoN1G17IBui8aclZVKPbfnQJKwcK5nMiL5BUxUIxNsA==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-env@^0.1.0-preview.6":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-0.1.0-preview.6.tgz#8ee0235da5f66e9bf4db672164265ee99a2dc147"
+  integrity sha512-x75/fs5mg6RONz5g9fY8jcUjn6tJ9Qfc1RfdNl/FjRza19zc/FGf0p86rt7uq6OF/8s9t0QnvAiH0ii03TFSPw==
+  dependencies:
+    "@aws-sdk/property-provider" "^0.1.0-preview.5"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-imds@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-0.1.0-preview.5.tgz#b0b67817db54988f5bf9ea3440cf7e7430514f2e"
+  integrity sha512-LSB2YjvVr3XqcvqxEfcRkN6qxXG/N0YrP3XIcb17NmJ5sqLQSDykCdOIONCX44FJ9coHpUXB6P10HtzzAghiNQ==
+  dependencies:
+    "@aws-sdk/property-provider" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-ini@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.5.tgz#72936d13eb4828d6a0f6cf4097a30dab31c9c588"
+  integrity sha512-h5YljWR3QDVECJqWs78zKXjg8/zZTV2MYbSMx0UqKwijIWsa6yfH3+G+XLJdkW3ZbvsVo3zsppZixjL59o/t9Q==
+  dependencies:
+    "@aws-sdk/property-provider" "^0.1.0-preview.5"
+    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-node@^0.1.0-preview.5":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-0.1.0-preview.7.tgz#2d81d4278f44d43358d5ca20d5638c49825deba7"
+  integrity sha512-Fjnr8SyfUhWlREOnzpRS/Wk5loqf0L3z1fOP6aCDmViPlAfDzCF83F0EkIqeBqTgVhCu40wysCs31nTrV8pWiw==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^0.1.0-preview.6"
+    "@aws-sdk/credential-provider-imds" "^0.1.0-preview.5"
+    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.5"
+    "@aws-sdk/credential-provider-process" "^0.1.0-preview.3"
+    "@aws-sdk/property-provider" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-process@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-0.1.0-preview.3.tgz#2ea73b939cab1f1f5082bec9cc6332a2f7bfc0e6"
+  integrity sha512-HVoWom235BXMFBbVrGI4G1k4V/e0kxAbjKIQm37lvm9rWrRDw/b0+T/TFM8bGoKVHGX89bGWDQa0cFYktSldSg==
+  dependencies:
+    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.5"
+    "@aws-sdk/property-provider" "^0.1.0-preview.5"
+    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/hash-node@^0.1.0-preview.4":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-0.1.0-preview.6.tgz#39747bb77f107988af25fd2a8f2b09383f1d6bb3"
+  integrity sha512-XGolfAQrNQzUwsiS24G1q0f/7Puwi7LZFlsGph+llMXt+aD6p9ROYDpRpZjHtL/VSwBWHUQYIv+ZQWrl5wkbig==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/util-buffer-from" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/hash-stream-node@^0.1.0-preview.5":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-stream-node/-/hash-stream-node-0.1.0-preview.7.tgz#40f8fcaf6bbb330a622d02e21a9b5a48c3cb2338"
+  integrity sha512-jWm48PEhJ1CcpVbD1SjLUDtlrvcw/ONQ7x3GQ0Vu/reJY0FCgt1DwXoESCLuPrPe6o2ztNiYZid+2u6mES0Peg==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/is-array-buffer@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-0.1.0-preview.3.tgz#3d4e0297f437dfaa00b25a000d526c02ccd2af6d"
+  integrity sha512-8SM7kBGkwH6JCKA6K1w4Jrj+EABFOPQkbPvwaf6BILYiUMUbgJvjOPjNQE2MrvRxJz50WAcZDHnlwhstuwIRnw==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/is-iterable@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-iterable/-/is-iterable-0.1.0-preview.3.tgz#292e9a44e3c2872f681a46daa715e3b5403dc86b"
+  integrity sha512-dmqXKd7BlAGAaOz1dvmBw5MeOy/94LOxIRv4i8I76JPyTJsxFKjzJIHeRMnQ/5WJ3/POhmb6ZjBW/GwS/upaFw==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/location-constraint-middleware@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/location-constraint-middleware/-/location-constraint-middleware-0.1.0-preview.5.tgz#ce83882339977ba4d60e183fc570057ca07c71a4"
+  integrity sha512-w6y2vzo5IaUQ6oE7gFvjcCMXyU2+Su6RJ4vOOqUjok+kZ1vgS9nll5FgdWEEWfQRB88dnBnQIuXeIa8DTTLXxg==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-content-length@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.5.tgz#7d8cbbb19d50d333e038510342da71534023c44e"
+  integrity sha512-T6IjQRTZyrFlvzYxihZBLsvHQ5EB3aMzXFsz7EcvJOBU9Y6btbG5gKOx7zN5lIsuv5+8+EpEIEA3QqR+PddvJg==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-expect-continue@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-0.1.0-preview.5.tgz#5dd9a496e380346fad8832d2e25882f22b4944b5"
+  integrity sha512-GJjlPyHoO05lOhQYuTnMA5+uayUQMNNV3zo2ktTiJ5ZyeSsstlBcJo80n1X5HhUi++PkkyC4Mumx+uJeGiTQvg==
+  dependencies:
+    "@aws-sdk/middleware-header-default" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-header-default@^0.1.0-preview.4", "@aws-sdk/middleware-header-default@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.5.tgz#89990a9c3f71d883531cb094727901af64dd1735"
+  integrity sha512-l0DYSuOrE/pRS93ziV+a47K78XY3EV5hNfr0mcbxh39c1Xh5MZe+jic1O9FeRfertOXZXCIAuHCnDf0ET/CKGQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-serializer@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serializer/-/middleware-serializer-0.1.0-preview.5.tgz#00a8355abc462679580d49969eea8c8513ce4208"
+  integrity sha512-iDPNjWmUz81FOj+23BX/6jpCUW/JWfeNWHaQcawa7jhMCcRmnBqHl9mEvQLz8xT0qmZRXcOUPx1/P6Aebi+hoQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-stack@^0.1.0-preview.5":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.6.tgz#683a308eb95ac6170c7181fd2c96e6f73da7e5cc"
+  integrity sha512-Zkj6MkRFS9f+VZye8QZU8Yd2tkv3pCCY1CtRmrDiFQ2fAXAWuMHHJ/aHA8norlVXE7409i+hRLLTRftupYU55Q==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/node-http-handler@^0.1.0-preview.5":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-0.1.0-preview.6.tgz#053b41a1fbb3d678ea0427e9b1120c808d0efbe1"
+  integrity sha512-40ZygkGi1YQ1y8weda2sUu+oXiiPfMEjiFRNE8tvT8gUgYnwv6RYECTeDKz7QM/wjVL/6dNOVLWl7tP0iwBGww==
+  dependencies:
+    "@aws-sdk/abort-controller" "^0.1.0-preview.5"
+    "@aws-sdk/querystring-builder" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/property-provider@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.5.tgz#7900d1c2acf070bfbe790304e159dbe72f7d1e74"
+  integrity sha512-1jqqNKbX5GFL/zVrMh+5YOsM4eBlvl46eaFVH+lK6sAUhw3DmigrTvrIb7WPt0ZJYYbzyOM+VL94+kaHItbT4A==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/protocol-rest@^0.1.0-preview.6":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-rest/-/protocol-rest-0.1.0-preview.7.tgz#dfcc125d66ea35854b0a28998ad521b098318669"
+  integrity sha512-pAhcaiAxhjalp+5P2zLbrqeNKwfbtGhlusCtwui5TP8ogphpATjn2uEAbDBtARv0wBrrNOF/8eNJlt+o4snE0w==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
+    "@aws-sdk/is-iterable" "^0.1.0-preview.3"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
+    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.6"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/util-error-constructor" "^0.1.0-preview.5"
+    "@aws-sdk/util-uri-escape" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/protocol-timestamp@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-timestamp/-/protocol-timestamp-0.1.0-preview.5.tgz#7805d40558a26c12a4b33c4103db179beaa9d77c"
+  integrity sha512-HYbENtsxUlkyxf5tpD/5HI4MlsRvjhhMW08SsUdD+EApNyITGItPaDhK335D4ijjpLQCSHvUgA0rl+IRr1WawA==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/query-error-unmarshaller@^0.1.0-preview.5":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/query-error-unmarshaller/-/query-error-unmarshaller-0.1.0-preview.6.tgz#e655f4b3983dc2af98c9b9b6d35ed9173dea0ccd"
+  integrity sha512-9OJbYYh4sCYMJQusQlmaoKGoz2Cg11cpOlauhmqkafzCHU8YsDHkCgqrlbIW4EvNyO29eWeblvYHdH7iJYSb/A==
+  dependencies:
+    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.6"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/util-error-constructor" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/querystring-builder@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-0.1.0-preview.5.tgz#d2028c51b3e0cfae4d2b3bea74927dfa70023db4"
+  integrity sha512-ZwA7m2E0GfO0sEqinear8B/oZ3QyHLgPST6JLhwPYnpzB/ZzYPktp+aF/RCZ6S9OEeIC61L7lmwNsLTRFuOrDQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/util-uri-escape" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/querystring-parser@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-0.1.0-preview.5.tgz#4b1d943a8b1c9383993b9d4264ac1544c44840f8"
+  integrity sha512-dKuGB/BsaCQaCYraOQf9B7UZyd35Q3+QJEG45cmOs719wb07YTR4fd/mtsPBhle6RYi0NGVmIhsO2VGlAYRfBw==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/region-provider@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-provider/-/region-provider-0.1.0-preview.5.tgz#5384b48805675f0623141c4a9cb629f9b5ec617b"
+  integrity sha512-CkZWBvUi0NT4JQ1AiikTe4cck4PSks+beL4bEDwsUpEHO0OxP9d4Nr/eP0o3FB3+eJIwkDqMKYskhdVFcZ+AlA==
+  dependencies:
+    "@aws-sdk/property-provider" "^0.1.0-preview.5"
+    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/response-metadata-extractor@^0.1.0-preview.5", "@aws-sdk/response-metadata-extractor@^0.1.0-preview.6":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/response-metadata-extractor/-/response-metadata-extractor-0.1.0-preview.6.tgz#7a0ff8ccd679d066032ca1f79e04a2ea11f7f62d"
+  integrity sha512-p4d9jf7Oe6UwbJcwDw2Z0N3ZDCkWsoAnET+qwEcymeHBlx5nj0AM+Kc0hXKnWUiDsmftQKfJCwQ53WLb2fTo+Q==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/retry-middleware@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/retry-middleware/-/retry-middleware-0.1.0-preview.5.tgz#f8d1466294ee18ceaa60e19a66e271af706288db"
+  integrity sha512-bxsY5LlUqrzqrGIJBDLjasiBzBzib+1fSLg6MR4DrYd9WmilnNKR+lmf592+enaR2K1DNdvmkfJz3CKl9HMZIg==
+  dependencies:
+    "@aws-sdk/service-error-classification" "^0.1.0-preview.3"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/s3-error-unmarshaller@^0.1.0-preview.2":
+  version "0.1.0-preview.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-error-unmarshaller/-/s3-error-unmarshaller-0.1.0-preview.2.tgz#c950b9c0a3d9395161b2d99d2d01e1d94835ecc0"
+  integrity sha512-3A6FUzFwGe34+1l8daxXaiTymZmb1LvVXNM+aapfJqRCM80vfbTEf+pzefIHCJAOhTCaSyhtkrs07iOpj3L1nw==
+  dependencies:
+    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.4"
+    "@aws-sdk/util-error-constructor" "^0.1.0-preview.4"
+    tslib "^1.8.0"
+
+"@aws-sdk/service-error-classification@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-0.1.0-preview.3.tgz#6e3720f361f637d0dbcff09f487997fa2ce3018d"
+  integrity sha512-3TXwADJL+HGOWyqdwx+pOdwr8L8LGbdxwHR0D05PP3skY+TP34F3ye2DJlyCll4S9vYzf9GlSbwJWviN9Sujrw==
+
+"@aws-sdk/shared-ini-file-loader@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-0.1.0-preview.3.tgz#215c5ed06564eb5ba96fa615f1ccb66667725147"
+  integrity sha512-1wuV2YpZm+sW4AZa7CBD3A3b7+vSHX0DWBgGaENYdqC+MUEl6lD57ZOUGLryPq5xv/tQfy8BC7QT+qDNHElcuw==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/signature-v4@^0.1.0-preview.5", "@aws-sdk/signature-v4@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.7.tgz#0c7c77e83b3178125742c53416f69ff86ab0855c"
+  integrity sha512-lVi1dJKEjKhNv88Ouo3UaZIintSHcaWGozI4JDwjGjaSsAg1WkkRS72Te6ur1+owJ0oHTcaXwzfQRjgX/qqTjA==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/util-hex-encoding" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/signing-middleware@^0.1.0-preview.5":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.7.tgz#55f3b5c4703fe7cd5999adbbd6629497588225fb"
+  integrity sha512-tmQcI3tdVMdxdOR8o17fHEyMRGepe8tEL+TPnvnD7TX0c8tkxZ+bHxRV9KU+s0DW+b2rWe7l+E1ytgS1tY04UA==
+  dependencies:
+    "@aws-sdk/signature-v4" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/ssec-middleware@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/ssec-middleware/-/ssec-middleware-0.1.0-preview.5.tgz#30c1610b8ec739a0014e6415a504ae761aaa8440"
+  integrity sha512-x5Yy7Di+6BBmD3vMiq8irsAmSqVQdCNuK2Ka41PmmuYIf4MjZaTUkXnknXbnCCkkUyoUYrri/CQyUTqLksw19A==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/stream-collector-node@^0.1.0-preview.4":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-node/-/stream-collector-node-0.1.0-preview.6.tgz#c3e3a14e3d622ae6133670cdb85ab122843c38ad"
+  integrity sha512-cmQfUMrBlm/vPXc9FpDyvI2n9MRgendGlQj9iSyR/DxmcNrf/yJoedSbfj7KzyfwFXmD2RB43rTgMoeXkYzpVQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/types@^0.1.0-preview.4", "@aws-sdk/types@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.5.tgz#d55946b363a107a3c72063df37ecc8b208de30a6"
+  integrity sha512-U5YNVOtAOsilZrszHWr+fdAwXgOccbVbnXG9gq1nIOOVv89zn3SAj7x/E5QrbcAhKPtJedXvk17i6DCcJlPxhg==
+
+"@aws-sdk/url-parser-node@^0.1.0-preview.4":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-node/-/url-parser-node-0.1.0-preview.6.tgz#d91fd6207841d713d85ed2bc519b6bce764c3bed"
+  integrity sha512-82d4bNcOUbHkrjX+dRvWnAsxoU5Ff+rstZHY2JWz2AgLXz+dlvurvmTewoPEb6ANmq3zQSqmHHXGzPFbjFt9SQ==
+  dependencies:
+    "@aws-sdk/querystring-parser" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/util-base64-node@^0.1.0-preview.2":
+  version "0.1.0-preview.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-0.1.0-preview.4.tgz#17271a49874b96e1e7b842cb0c564a3a7260137f"
+  integrity sha512-L9O3lMWB7y2xVIgg/nSJ7xZLVFmxMCk1maaup3CoL5USLqB7n7ngpf/WAH2LyhaGo8Og8TrAKt4BizpxbZU7wg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/util-body-length-node@^0.1.0-preview.3":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-0.1.0-preview.5.tgz#330628a9b6e56a7766f00c7ae5074e5090efdec5"
+  integrity sha512-ZmqB7E/RizTe8ajxLyXdshoyzQg47CAkbnCK7yRE4A9N7XMEUgzyFVXuKT08DmbAwYSYWI5jaUwm3jpMKqG+bw==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-buffer-from@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-0.1.0-preview.3.tgz#a95aa03f6d82dccd853b110f15c5479c83204c58"
+  integrity sha512-n78cUmI1SbluJgTgyqp24GgNQ3A5NUGB4rwRAoID7k7JpsiNJUWTXkijl3hxfNov2sEjMWvdQIGvAF6F/Q2mfw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/util-error-constructor@^0.1.0-preview.4", "@aws-sdk/util-error-constructor@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-error-constructor/-/util-error-constructor-0.1.0-preview.5.tgz#d71ebd73cfec7e9160a8d701a488ceee6ca8c0ae"
+  integrity sha512-VT3DatjCLv5fkm8Q7Xslt50mN5ksWUminWzBv3bte2RWIG+zM8JfuO1UeswAjARe4b6N+UgpOVEjLLfE4MMbmQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/util-hex-encoding@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-0.1.0-preview.3.tgz#4847f0733dfe2e35aefde8423fefefad4073d355"
+  integrity sha512-X/Qq5e2H4/EQ0WEwWUiSxGbFARk7IKZpa+E4pzQm49sxS2omVsvuphcr4yYJq4SZKEtuB2w2nHMr7NmGlWt4Xg==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-uri-escape@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-0.1.0-preview.3.tgz#bede79215aa2a78554b4223f43f7820535236583"
+  integrity sha512-axArIOq8+2PKjY9Fz+LKfCY127rjWQD50F1DAhCC0BV3mrG0OlhcQ8uKaNfMXVrveTqT+QYvrpTsrziHYjjTQw==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/util-user-agent-node@^0.1.0-preview.5":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-0.1.0-preview.7.tgz#8818fe70b4e5d27907c258fbd5d75af081998274"
+  integrity sha512-28mZIA6BFB3vSmmbsfarTzixFBebthOQMcfUp7jfDVOgSCyhrB7JgYkKc6u/pupVM+ppvOaZxcSs5cDsqI5KwQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/util-utf8-node@^0.1.0-preview.2":
+  version "0.1.0-preview.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-0.1.0-preview.4.tgz#8dc8e0ce43f6dc04bbcab00c87f29f9f89ebb7ad"
+  integrity sha512-FxIWpC4LdKiJgJgiaLWMdZY/DbreSIRgVGO9cOlV5fI59KdN+2Aqb6sLnlp7yVbo2hiL0Hlcv7fcf4MEtELn0g==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/xml-body-builder@^0.1.0-preview.4":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-body-builder/-/xml-body-builder-0.1.0-preview.5.tgz#b81e1563295dd6a7364a487e1495aae80c51322a"
+  integrity sha512-aZ8koCRV3+bgZjcFK2ixzB3y38/TMI6qsHCEYenYIY8UbLDNJNwr6xIFKlwdSgdANcTWBuScfjg2FdBa/K9SJQ==
+  dependencies:
+    "@aws-sdk/is-iterable" "^0.1.0-preview.3"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/xml-builder" "^0.1.0-preview.3"
+    tslib "^1.8.0"
+
+"@aws-sdk/xml-body-parser@^0.1.0-preview.5":
+  version "0.1.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-body-parser/-/xml-body-parser-0.1.0-preview.6.tgz#8a2ed7c5079287c34eaae4ff848c2a1a417b97e4"
+  integrity sha512-6quo9AqyUfsnE9+TwlgU5X5EZAXeAIm8D+QPhzerk4KrfDtJrV6WFpE+hkj1L3STC6n3U1M5jMhsYW8Qs3RsvA==
+  dependencies:
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.5"
+    tslib "^1.8.0"
+
+"@aws-sdk/xml-builder@^0.1.0-preview.3":
+  version "0.1.0-preview.3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-0.1.0-preview.3.tgz#ab338ae7b8d0e58854f8af69acfa86da86f767ba"
+  integrity sha512-TwahSQDyO0yjiY2GXSDw2f4FP6lgj8LaR/MtmjAHZeP6M8dw5ma08R2pLI5CV+paNIACnnnmRuSW2Dmj0c/jOQ==
+  dependencies:
+    tslib "^1.8.0"
+
 "@azure/ms-rest-js@^2.0.0":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.0.4.tgz#1a1e0e3b2315619d675ebc04c4e8e0d98ce8aa2b"
@@ -16098,7 +16564,7 @@ tsconfig-paths@^3.8.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.10.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@1.10.0, tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
Temporary working that disables the 'api' packages from being
hoisted into the root directory. When a user would run
'docker-compose up', the docker volume on 'node_modules' has
symlinks to the root bin folder. Because these symlinks cannot
be resolved inside the docker container this causes 'nodemon not found'
errors