### PR TITLE
Migrate terraform to using Terraform Cloud as backend

### DIFF
--- a/deploy/terraform.tf
+++ b/deploy/terraform.tf
@@ -26,6 +26,19 @@ provider "digitalocean" {
   spaces_secret_key = "${var.spaces_secret_key}"
 }
 
+# See https://www.terraform.io/docs/cloud/migrate/index.html for migration from
+# local to Terraform Cloud
+terraform {
+  backend "remote" {
+    hostname = "app.terraform.io"
+    organization = "mstacm"
+
+    workspaces {
+      name = "mstacm_org"
+    }
+  }
+}
+
 # Add local ssh key for accessing the various resources
 resource "digitalocean_ssh_key" "default" {
   name       = "Terraform Key"


### PR DESCRIPTION
# Pull Request Description
Migrates the terraform local deploy into [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html). The nice thing about using this is that we aren't necessarily locked-in as we can simply download the state file and leave at any time. However, this will automatically handle deployment of infrastructure on `master` so no one will have to mess with it (except for approving changes)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
