### PR TITLE
Add generated migration to add shirts to db

### DIFF
--- a/apps/api/src/migrations/1586508104823-ShirtMembership.ts
+++ b/apps/api/src/migrations/1586508104823-ShirtMembership.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ShirtMembership1586508104823 implements MigrationInterface {
+  name = "ShirtMembership1586508104823";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "shirtReceived" boolean NOT NULL DEFAULT false`,
+      undefined
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP COLUMN "shirtReceived"`,
+      undefined
+    );
+  }
+}


### PR DESCRIPTION
We merged the front end that includes the membership tool and shirts as well as the backend for shirts, but we never generated the production migrations, so here they are.