### PR TITLE
Add Vagrant and new Instructions for Development Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ yarn-debug.log*
 yarn-error.log*
 
 web.env
+
+.vagrant/

--- a/apps/Vagrantfile
+++ b/apps/Vagrantfile
@@ -1,0 +1,18 @@
+unless Vagrant.has_plugin?("vagrant-docker-compose")
+  system("vagrant plugin install vagrant-docker-compose")
+  puts "Dependencies installed, please try the command again."
+  exit
+end
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  graphql_port = 80
+  traefik_port = 8080
+
+  config.vm.network(:forwarded_port, guest: graphql_port, host: graphql_port)
+  config.vm.network(:forwarded_port, guest: traefik_port, host: traefik_port)
+
+  config.vm.provision :docker
+  config.vm.provision :docker_compose, yml: ["/vagrant/docker-compose.yml", "/vagrant/docker-compose.override.yml"], run: "always"
+end

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,6 @@ FROM node:12
 WORKDIR /server
 
 COPY . /server
-ADD package.json /server/package.json
 RUN yarn
 
 EXPOSE 4000

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -33,14 +33,30 @@ all frontend clients. Primary features include but are not limited to:
 To get a local copy up and running follow these simple steps.
 
 ### Prerequisites
-+ [Git](https://git-scm.com/download/)
-+ [Docker](https://docs.docker.com/install/)
-+ [Docker Compose](https://docs.docker.com/compose/install/)
-+ [NodeJS](https://nodejs.org/en/)
-+ [Yarn](https://yarnpkg.com/)
-+ (optional) [python](https://www.python.org/downloads/) - This will allow you
+#### Universal (All Platforms)
+  + [Git](https://git-scm.com/download/)
+  + [NodeJS](https://nodejs.org/en/)
+  + [Yarn](https://yarnpkg.com/)
+  + (optional) [python](https://www.python.org/downloads/) - This will allow you
   to more easily configure the environment variables, but I will show you how to
   do it manually.
+  
+#### Windows
+
+  **Versions that support [WSL 2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-index) (currently Windows 10, Version 2004, Build 19041 or higher)**
+  * Install WSL 2
+  * Install [Docker Desktop and enable WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/)
+
+  **Other versions**
+  * Install [Virtualbox](https://www.virtualbox.org/)
+  * Install [Vagrant](https://www.vagrantup.com/)
+
+#### Linux
+* Install [Docker](https://docs.docker.com/install/)
+* Install [Docker Compose](https://docs.docker.com/compose/install/)
+
+#### MacOS
+* Install [Docker Desktop](https://docs.docker.com/docker-for-mac/install/)
 
 ### Installation
 1. Clone the mstacm.org repository using Git Bash:
@@ -85,10 +101,21 @@ To get a local copy up and running follow these simple steps.
         # Now edit the ./.docker/web.env with the appropriate values.
         # Instructions how are located in the file.
         ```
+5. Navigate back to the `apps` directory
+    ```bash
+    cd ..
+    ```
 
-5. Start the docker containers using `docker-compose`:
+5. Start the docker containers.
+    
+    **If using docker:**
     ```sh
-    cd .. && docker-compose up
+    docker-compose up
+    ```
+
+    **If using Vagrant**
+    ```bash
+    vagrant up
     ```
 
 6. If everything goes well, the last lines of output should look like:
@@ -99,6 +126,7 @@ To get a local copy up and running follow these simple steps.
     phoenix_web_1    |
     phoenix_web_1    |       http://localhost/graphql || http://localhost:4000/graphql
     ```
+    > To access these with **Vagrant** use `vagrant ssh` to log into the machine and `docker logs vagrant_phoenix_web_1` to view the logs. `docker logs -f vagrant_phoenix_web_1` will continously update if new logs come in.
     
 7. Navigate to [http://localhost/graphql](http://localhost/graphql). **NOTE**:
    if you are using Docker on Windows 10 Home, you need to put the IP of your
@@ -163,6 +191,17 @@ but the lessons apply to both clients.
 [![Insomnia First Query](images/insomnia-first-query.png)](images/insomnia-first-query.png)
 [![Insomnia Autocomplete](images/insomnia-autocomplete.png)](images/graphql-localhost-playground.png)
 
+### When you are done
+#### Docker
+Ctrl-C the terminal where docker-compose is running
+> Sometimes you need to run docker-compose up again and then Ctrl-C that. You should see "stopping".
+
+#### Vagrant
+Run the following:
+```bash
+vagrant halt
+```
+> This stops the virtual machine and the docker instance running within.
 
 <!-- ROADMAP -->
 ## Roadmap

--- a/apps/api/nodemon.json
+++ b/apps/api/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["src"],
   "ext": "ts",
   "ignore": ["src/**/*.spec.ts"],
-  "exec": "ts-node -r tsconfig-paths/register src/main.ts"
+  "exec": "yarn ts-node -r tsconfig-paths/register src/main.ts"
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -58,7 +58,7 @@
     "nodemon": "^1.19.3",
     "prettier": "^1.18.2",
     "ts-jest": "^24.0.2",
-    "ts-node": "^8.4.1",
+    "ts-node": "^8.10.1",
     "tsconfig-paths": "^3.8.0",
     "typescript": "^3.6.4"
   },

--- a/apps/api/yarn.lock
+++ b/apps/api/yarn.lock
@@ -5820,6 +5820,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.5.6:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -6285,15 +6293,15 @@ ts-jest@^24.0.2:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-node@^8.4.1:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+ts-node@^8.10.1:
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.1.tgz#77da0366ff8afbe733596361d2df9a60fc9c9bd3"
+  integrity sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.6"
+    source-map-support "^0.5.17"
     yn "3.1.1"
 
 tsconfig-paths@^3.8.0:

--- a/apps/docker-compose.override.yml
+++ b/apps/docker-compose.override.yml
@@ -14,7 +14,7 @@ services:
     # Testing migrations
     # command: bash -c "yarn build && yarn start:prod"
     command: yarn start:dev
-    build: ./api
+    build: api
     volumes:
       - ./api:/server
     environment:


### PR DESCRIPTION
Developers have had issues setting up the frontend and backend for a while now. This aims to help solve it by giving developers more options. Vagrant allows them to easily run our backend in a worst case situation (cannot get docker running) while also giving more instructions for new versions of windows.