### PR TITLE
(#289) Remove black outlines on focus

### DIFF
--- a/apps/web/src/static/css/App.css
+++ b/apps/web/src/static/css/App.css
@@ -46,6 +46,8 @@ body {
   font-family: "Nunito Sans", sans-serif;
 }
 
+/* Issue #289 - Outlines on buttons and textfields */
+/* TODO: Add back a visual focus indicator for accessibility's sake */
 :focus {
   outline: none;
 }

--- a/apps/web/src/static/css/App.css
+++ b/apps/web/src/static/css/App.css
@@ -45,3 +45,7 @@ body {
   padding: 0;
   font-family: "Nunito Sans", sans-serif;
 }
+
+:focus {
+  outline: none;
+}


### PR DESCRIPTION
# Pull Request Description

By default, most browsers place a black outline around the currently-focused element. On mstacm.org, it looks kind of ugly, so some people want it changed. As a quick fix, this commit completely up removes the black outline around focused elements.
People who use Tab to navigate  webpages aren't going to be too happy though, as it's their often only indication of what their cursor is currently on. So I'm hoping we can eventually come up with something else that adds that functionality back in the future.

// Side note: I'm not sure if this is the correct file to put this code in. Please let me know if it isn't.

# Checklist:

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [​X] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes
- [N/A] Any dependent changes have been merged and published in downstream modules
